### PR TITLE
[Risky] Restart mesos agents/masters only on failure

### DIFF
--- a/templates/default/systemd.erb
+++ b/templates/default/systemd.erb
@@ -5,7 +5,7 @@ Wants=network.target
 
 [Service]
 ExecStart=<%= @wrapper %>
-Restart=always
+Restart=on-failure
 RestartSec=20
 LimitNOFILE=16384
 


### PR DESCRIPTION
Having "Restart=always" prevent to cleanly drain slaves since process is
stopping cleanly at the end of the drain.
Changing this setting on masters is not supposed to have impact (apart
from a restart)

Change-Id: I42fbdf38d2119447520d2db907c900a1e91eca79