### PR TITLE
Allow to install latest available mesos version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,6 +7,8 @@ default['java']['jdk_version'] = '8'
 default['mesos']['repo']       = true
 
 # Mesosphere Mesos version.
+# overriding this attribute to nil in a wrapper cookbook will force the
+# cookbook to use the latest version available in the repositories
 default['mesos']['version']    = '1.1.0'
 
 default['mesos']['package_options'] = case node['platform_family']

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -40,11 +40,15 @@ when 'debian'
   end
 
   package 'mesos' do
-    action :install
     # --no-install-recommends to skip installing zk. unnecessary.
     options node['mesos']['package_options'].join(' ')
-    # Glob is necessary to select the deb version string
-    version "#{node['mesos']['version']}*"
+    if node['mesos']['version']
+      action :install
+      # Glob is necessary to select the deb version string
+      version "#{node['mesos']['version']}*"
+    else
+      action :upgrade
+    end
   end
 when 'rhel'
   %w[unzip libcurl subversion].each do |pkg|
@@ -54,7 +58,11 @@ when 'rhel'
   end
 
   yum_package 'mesos' do
-    version node['mesos']['version']
+    if node['mesos']['version']
+      version node['mesos']['version']
+    else
+      action :upgrade
+    end
     options node['mesos']['package_options'].join(' ')
   end
 end


### PR DESCRIPTION
This patch allows wrapper cookbooks to choose to upgrade to the latest
version available in repositories.

This behavior can be useful for test nodes where you always want latest
version of rpm/deb.
For instance, a cluster could have a few percent of slaves using latest
version of mesos rpm to allow users to test some features in advance.

Change-Id: Idcf99ab4a3925401d52ee511960e0c6f28001214