### PR TITLE
[hotfix] reload systemd configuration when necessary

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -116,6 +116,7 @@ execute 'systemctl-daemon-reload' do
   command '/bin/systemctl --system daemon-reload'
   subscribes :run, 'template[mesos-master-init]'
   subscribes :run, 'template[mesos-slave-init]'
+  notifies :restart, 'service[mesos-slave]', :immediately
   action :nothing
   only_if { node['mesos']['init'] == 'systemd' }
 end

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -66,6 +66,12 @@ template 'mesos-slave-wrapper' do
             syslog: node['mesos']['slave']['syslog'])
 end
 
+execute 'systemd-daemon-reload' do
+  action :nothing
+  command 'systemctl daemon-reload'
+  subscribes :run, 'template[mesos-slave-init]'
+end
+
 # Mesos master service definition
 service 'mesos-slave' do
   case node['mesos']['init']

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -66,12 +66,6 @@ template 'mesos-slave-wrapper' do
             syslog: node['mesos']['slave']['syslog'])
 end
 
-execute 'systemd-daemon-reload' do
-  action :nothing
-  command 'systemctl daemon-reload'
-  subscribes :run, 'template[mesos-slave-init]'
-end
-
 # Mesos master service definition
 service 'mesos-slave' do
   case node['mesos']['init']


### PR DESCRIPTION
This patch is an ugly bugfix that will break non-systemd systems.
It will make sure changes in systemd unit are loaded by systemd before restart happens