### PR TITLE
Fix Mesos slave restart on Systemd unit change

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -116,7 +116,6 @@ execute 'systemctl-daemon-reload' do
   command '/bin/systemctl --system daemon-reload'
   subscribes :run, 'template[mesos-master-init]'
   subscribes :run, 'template[mesos-slave-init]'
-  notifies :restart, 'service[mesos-slave]', :immediately
   action :nothing
   only_if { node['mesos']['init'] == 'systemd' }
 end

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -79,5 +79,6 @@ service 'mesos-slave' do
   supports status: true, restart: true
   subscribes :restart, 'template[mesos-slave-init]'
   subscribes :restart, 'template[mesos-slave-wrapper]'
+  subscribes :restart, 'execute[systemctl-daemon-reload]', :immediately
   action %i[enable start]
 end


### PR DESCRIPTION
The `notifies` is not compatible with Mesos master only nodes.