### PR TITLE
[Breaking] Fork forever

### DIFF
--- a/.kitchen.ec2.yml
+++ b/.kitchen.ec2.yml
@@ -29,46 +29,6 @@ provisioner:
   require_chef_omnibus: 12.5.1
 
 platforms:
-  - name: amazon-2016.09.0
-    run_list:
-      - recipe[yum]
-    driver:
-      image_id: ami-b04e92d0
-    transport:
-      username: ec2-user
-  # https://cloud-images.ubuntu.com/locator/ec2/
-  - name: ubuntu-16.04
-    run_list:
-      - recipe[apt]
-      - recipe[curl]
-    driver:
-      image_id: ami-a9d276c9
-  - name: ubuntu-15.10
-    run_list:
-      - recipe[apt]
-      - recipe[curl]
-    driver:
-      image_id: ami-1863a178
-  - name: ubuntu-14.04
-    run_list:
-      - recipe[apt]
-      - recipe[curl]
-    driver:
-      image_id: ami-01f05461
-  - name: ubuntu-12.04
-    run_list:
-      - recipe[apt]
-      - recipe[curl]
-    driver:
-      image_id: ami-adcd69cd
-  # https://wiki.debian.org/Cloud/AmazonEC2Image
-  - name: debian-8.6
-    run_list:
-      - recipe[apt]
-      - recipe[curl]
-    driver:
-      image_id: ami-4e1cc32e
-  # https://wiki.centos.org/Cloud/AWS
   - name: centos-7
     run_list:
       - recipe[yum]
@@ -77,18 +37,10 @@ platforms:
       block_device_mappings:
         - device_name: /dev/sda1
           ebs: {volume_type: gp2, delete_on_termination: true}
-  - name: centos-6
-    run_list:
-      - recipe[yum]
-    driver:
-      image_id: ami-05cf2265
-      block_device_mappings:
-        - device_name: /dev/sda1
-          ebs: {volume_type: gp2, delete_on_termination: true}
 
 suites:
   - &default
-    name: 1-1-0
+    name: 1-4-0
     run_list:
       - recipe[mesos::master]
       - recipe[mesos::slave]
@@ -98,12 +50,7 @@ suites:
           flags:
             attributes: 'attribute01:value01;attribute02:value02'
   - <<: *default
-    name: 1-0-1
+    name: 1-7-0
     attributes:
       mesos:
-        version: 1.0.1
-  - <<: *default
-    name: 1-0-0
-    attributes:
-      mesos:
-        version: 1.0.0
+        version: 1.7.0

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,30 +9,12 @@ provisioner:
   require_chef_omnibus: 12.14.60
 
 platforms:
-  - name: ubuntu-16.04
-    run_list: ['recipe[apt]', 'recipe[curl]']
-  - name: ubuntu-15.10
-    run_list: ['recipe[apt]', 'recipe[curl]']
-  - name: ubuntu-14.04
-    run_list: ['recipe[apt]', 'recipe[curl]']
-  - name: ubuntu-12.04
-    run_list: ['recipe[apt]', 'recipe[curl]']
-  - name: debian-8.6
-    run_list: ['recipe[apt]']
-    attributes: {java: {jdk_version: '7'}}
   - name: centos-7.2
     run_list: ['recipe[yum]']
-  - name: centos-6.8
-    run_list: ['recipe[yum]']
-# Oracle Linux
-# - name: box-cutter/ol68
-#   run_list: ['recipe[yum]']
-# - name: box-cutter/ol72
-#   run_list: ['recipe[yum]']
 
 suites:
   - &default
-    name: 1-1-0
+    name: 1-4-0
     run_list:
       - recipe[mesos::master]
       - recipe[mesos::slave]
@@ -42,8 +24,5 @@ suites:
           flags:
             attributes: 'attribute01:value01;attribute02:value02'
   - <<: *default
-    name: 1-0-1
-    attributes: {mesos: {version: '1.0.1'}}
-  - <<: *default
-    name: 1-0-0
-    attributes: {mesos: {version: '1.0.0'}}
+    name: 1-7-0
+    attributes: {mesos: {version: '1.7.0'}}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 Mesos Cookbook
 ==============
-[![Cookbook](http://img.shields.io/cookbook/v/mesos.svg)](https://supermarket.chef.io/cookbooks/mesos)
-[![Build Status](https://secure.travis-ci.org/mdsol/mesos_cookbook.png?branch=master)](http://travis-ci.org/mdsol/mesos_cookbook)
-[![Gitter chat](https://img.shields.io/badge/Gitter-mdsol%2Fmesos_cookbook-brightgreen.svg)](https://gitter.im/mdsol/mesos_cookbook)
+
+** Note ** : we are maintaining this cookbook for Criteo usage based on the work from mdsol and other maintainers.
+Since the upstream cookbook is no longer active/maintained, we'll keep this cookbook updated.
+It might be tailored to our usage (only support centos 7+ for instance) but should be usable by anyone with a similar configuration.
 
 Application cookbook for installing the [Apache Mesos][] cluster manager.
 Mesos provides efficient resource isolation and sharing across distributed
@@ -18,7 +19,6 @@ Platform
 --------
 Tested on
 
-* Debian 8.6 (with Java 7)
 * CentOS 7.2
 
 Supported Mesos versions
@@ -26,11 +26,10 @@ Supported Mesos versions
 
 This cookbook is tested against the following Apache Mesos versions:
 
+* 1.4.0
 * 1.1.0
-* 1.0.1
-* 1.0.0
 
-We intend to support at most the three latest versions of Apache Mesos.
+We intend to support at most the mesos version used in Criteo and the latest official release.
 
 Attributes
 ----------
@@ -87,14 +86,10 @@ Dependencies
 
 The following cookbooks are dependencies:
 
-* [apt][]
 * [yum][]
 * [java][]
 * [systemd][]
 
-The following cookbooks are suggested:
-
-* [exhibitor][] (used for discovering ZooKeeper ensembles via [Netflix Exhibitor][])
 
 Usage
 -----
@@ -162,10 +157,8 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 
 [Apache Mesos]: http://mesos.apache.org
-[Netflix Exhibitor]: https://github.com/Netflix/exhibitor
 [Mesosphere]: http://mesosphere.io
 [Medidata Solutions]: http://www.mdsol.com
 [exhibitor]: https://github.com/SimpleFinance/chef-exhibitor
-[apt]: https://github.com/opscode-cookbooks/apt
 [yum]: https://github.com/chef-cookbooks/yum
 [java]: https://github.com/agileorbit-cookbooks/java

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,7 +9,7 @@ default['mesos']['repo']       = true
 # Mesosphere Mesos version.
 # overriding this attribute to nil in a wrapper cookbook will force the
 # cookbook to use the latest version available in the repositories
-default['mesos']['version']    = '1.1.0'
+default['mesos']['version']    = '1.7.0'
 
 default['mesos']['package_options'] = case node['platform_family']
                                       when 'debian'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,20 +1,18 @@
 # frozen_string_literal: true
 
 name             'mesos'
-maintainer       'Ray Rodriguez'
-maintainer_email 'rayrod2030@gmail.com'
+maintainer       'Criteo'
+maintainer_email 'g.seux@criteo.com'
 license          'Apache-2.0'
 description      'Installs/Configures Apache Mesos'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '4.0.0'
-source_url       'https://github.com/mdsol/mesos_cookbook'
-issues_url       'https://github.com/mdsol/mesos_cookbook/issues'
+source_url       'https://github.com/criteo-forks/mesos_cookbook'
+issues_url       'https://github.com/criteo-forks/mesos_cookbook/issues'
 
-%w[ubuntu debian centos amazon scientific oracle].each do |os|
-  supports os
-end
+supports 'centos'
 
-%w[java apt yum].each do |cookbook|
+%w[java yum].each do |cookbook|
   depends cookbook
 end
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -24,24 +24,6 @@ include_recipe 'java'
 include_recipe 'mesos::repo' if node['mesos']['repo']
 
 case node['platform_family']
-when 'debian'
-  %w[unzip default-jre-headless libcurl3 libsvn1].each do |pkg|
-    package pkg do
-      action :install
-    end
-  end
-
-  package 'mesos' do
-    # --no-install-recommends to skip installing zk. unnecessary.
-    options node['mesos']['package_options'].join(' ')
-    if node['mesos']['version']
-      action :install
-      # Glob is necessary to select the deb version string
-      version "#{node['mesos']['version']}*"
-    else
-      action :upgrade
-    end
-  end
 when 'rhel'
   %w[unzip libcurl subversion].each do |pkg|
     yum_package pkg do

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -20,16 +20,6 @@
 #
 
 case node['platform_family']
-when 'debian'
-  include_recipe 'apt'
-
-  apt_repository 'mesosphere' do
-    uri "http://repos.mesosphere.io/#{node['platform']}"
-    distribution node['lsb']['codename']
-    keyserver 'hkp://keyserver.ubuntu.com:80'
-    key 'E56151BF'
-    components ['main']
-  end
 when 'rhel'
   include_recipe 'yum'
 


### PR DESCRIPTION
Upstream cookbook is not maintained anymore (PR pending for >1y).
This cookbook is useful for us, let's tailor it to our needs.

This patch:
- fully remove anything related to other distro than centos7
- update test suite (not tested automatically by travis yet)
- support only latest mesos version and the oneused by criteo

Change-Id: I08b9b0c902c872ac05812767d9b4d089c6ca8399