### PR TITLE
Remove syslog behavior

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,9 +28,6 @@ default['mesos']['master']['bin']                   = '/usr/sbin/mesos-master'
 # Environmental variables set before calling the mesos master process.
 default['mesos']['master']['env']['ULIMIT']         = '-n 16384'
 
-# Send stdout and stderr to syslog.
-default['mesos']['master']['syslog']                = true
-
 # Mesos master command line flags.
 # http://mesos.apache.org/documentation/latest/configuration/
 default['mesos']['master']['flags']['port']          = 5050
@@ -48,9 +45,6 @@ default['mesos']['slave']['bin']                    = '/usr/sbin/mesos-slave'
 
 # Environmental variables set before calling the mesos-slave process.
 default['mesos']['slave']['env']['ULIMIT']          = '-n 16384'
-
-# Send stdout and stderr to syslog.
-default['mesos']['slave']['syslog']                 = true
 
 # Mesos slave command line flags
 # http://mesos.apache.org/documentation/latest/configuration/

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -58,8 +58,7 @@ template 'mesos-master-wrapper' do
   mode '0750'
   source 'wrapper.erb'
   variables(bin: node['mesos']['master']['bin'],
-            flags: node['mesos']['master']['flags'],
-            syslog: node['mesos']['master']['syslog'])
+            flags: node['mesos']['master']['flags'])
   notifies :restart, 'service[mesos-master]'
 end
 

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -60,8 +60,7 @@ template 'mesos-slave-wrapper' do
   mode '0750'
   source 'wrapper.erb'
   variables(bin: node['mesos']['slave']['bin'],
-            flags: node['mesos']['slave']['flags'],
-            syslog: node['mesos']['slave']['syslog'])
+            flags: node['mesos']['slave']['flags'])
   notifies :restart, 'service[mesos-slave]'
 end
 

--- a/templates/default/wrapper.erb
+++ b/templates/default/wrapper.erb
@@ -4,12 +4,6 @@
 # set ulimit if defined
 [[ ! ${ULIMIT:-} ]] || ulimit $ULIMIT
 
-<%- if @syslog -%>
-# stdout and stderr to syslog
-exec 1> >(exec logger -p user.info -t "<%= ::File.basename(@bin) %>")
-exec 2> >(exec logger -p user.err  -t "<%= ::File.basename(@bin) %>")
-<%- end -%>
-
 # mesos binary configuration
 exec <%= @bin %> \
 <%- @flags.sort.each do |flag, value|                                      -%>


### PR DESCRIPTION
This cookbook is now specialized for systemd so we don't need to forward
logs to logger (which is journald under the hood) and can let regular
log goes to journald when launched as a service.

It will also make manual debugging easier (you can sudo /etc/mesos-chef/mesos-master
and directly reads logs)

Change-Id: Ibf5583f5df50ff1c2c86d1fde5fceefd2f0c0f03