### PR TITLE
[BUGFIX] When Mesos slave was failing, it couldn't recover executors

### DIFF
--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -82,6 +82,7 @@ systemd_service 'mesos-slave' do
   service do
     environment_file '/etc/mesos-chef/mesos-slave-environment'
     exec_start '/etc/mesos-chef/mesos-slave'
+    kill_mode 'process'
     restart 'on-failure'
     restart_sec 20
     limit_nofile 16384


### PR DESCRIPTION
Systemd was handling the killing of child processes, which basically killed all executors (being children of the slave).
As a result the executor could not reconnect to the slave restarted (as it is not present).

The is caused by the default killmode for systemd is controlgroup.