### PR TITLE
Avoid updating "configuration validation" resources at each run

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,5 @@ Metrics/LineLength:
   Enabled: false
 Style/ExtraSpacing:
   Enabled: false
+Metrics/AbcSize:
+  Enabled: false

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -25,20 +25,24 @@ end
 
 include_recipe 'mesos::install'
 
+def unknown_flags(node)
+  # Get Mesos --help
+  help = Mixlib::ShellOut.new("#{node['mesos']['master']['bin']} --help")
+  help.run_command
+  help.error!
+  # Extract options
+  options = help.stdout.strip.scan(/^  --(?:\[no-\])?(\w+)/).flatten - ['help']
+  node['mesos']['master']['flags'].keys.reject { |flag| options.include?(flag) }
+end
+
 # Mesos configuration validation
 ruby_block 'mesos-master-configuration-validation' do
   block do
-    # Get Mesos --help
-    help = Mixlib::ShellOut.new("#{node['mesos']['master']['bin']} --help")
-    help.run_command
-    help.error!
-    # Extract options
-    options = help.stdout.strip.scan(/^  --(?:\[no-\])?(\w+)/).flatten - ['help']
-    # Check flags are in the list
-    node['mesos']['master']['flags'].keys.each do |flag|
+    unknown_flags.each do |flag|
       Chef::Application.fatal!("Invalid Mesos configuration option: #{flag}. Aborting!", 1000) unless options.include?(flag)
     end
   end
+  only_if { unknown_flags(node).any? }
 end
 
 # ZooKeeper Exhibitor discovery

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -25,20 +25,25 @@ end
 
 include_recipe 'mesos::install'
 
+def unknown_flags(node)
+  # Get Mesos --help
+  help = Mixlib::ShellOut.new("#{node['mesos']['slave']['bin']} --help --work_dir=#{node['mesos']['slave']['flags']['work_dir']}")
+  help.run_command
+  help.error!
+  # Extract options
+  options = help.stdout.strip.scan(/^  --(?:\[no-\])?(\w+)/).flatten - ['help']
+  # Check flags are in the list
+  node['mesos']['slave']['flags'].keys.reject { |flag| options.include?(flag) }
+end
+
 # Mesos configuration validation
 ruby_block 'mesos-slave-configuration-validation' do
   block do
-    # Get Mesos --help
-    help = Mixlib::ShellOut.new("#{node['mesos']['slave']['bin']} --help --work_dir=#{node['mesos']['slave']['flags']['work_dir']}")
-    help.run_command
-    help.error!
-    # Extract options
-    options = help.stdout.strip.scan(/^  --(?:\[no-\])?(\w+)/).flatten - ['help']
-    # Check flags are in the list
-    node['mesos']['slave']['flags'].keys.each do |flag|
+    unknown_flags(node).each do |flag|
       Chef::Application.fatal!("Invalid Mesos configuration option: #{flag}. Aborting!", 1000) unless options.include?(flag)
     end
   end
+  only_if { unknown_flags(node).any? }
 end
 
 # ZooKeeper Exhibitor discovery


### PR DESCRIPTION
This makes chef-client log harder to read and understand

Change-Id: I4ad4f80f3a1cb498d104f3e68707a719a83c0e65