### PR TITLE
Make explicit dependency between mesos-* and journald

### DIFF
--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -75,6 +75,8 @@ systemd_service 'mesos-master' do
     description 'Mesos mesos-master'
     after 'network.target'
     wants 'network.target'
+    # see https://jira.apache.org/jira/browse/MESOS-9772
+    requires 'systemd-journald.service'
   end
 
   service do

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -77,6 +77,8 @@ systemd_service 'mesos-slave' do
     description 'Mesos mesos-slave'
     after 'network.target'
     wants 'network.target'
+    # see https://jira.apache.org/jira/browse/MESOS-9772
+    requires 'systemd-journald.service'
   end
 
   service do


### PR DESCRIPTION
Due to https://jira.apache.org/jira/browse/MESOS-9772, mesos processes
stop logging and working correctly when journald is restarted.
Using requires allows to have mesos-* process restarted when journald
is.

Change-Id: Ie9f2666b2975d2f596b54e00dfca1bff8ce9ea96