### PR TITLE
Use a dedicated user for mesos master

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,8 @@ default['mesos']['package_options'] = case node['platform_family']
 # Mesos master binary location.
 default['mesos']['master']['bin']                   = '/usr/sbin/mesos-master'
 
+default['mesos']['master']['user']                  = 'mesosmaster'
+
 # Environmental variables set before calling the mesos master process.
 default['mesos']['master']['env']['ULIMIT']         = '-n 16384'
 


### PR DESCRIPTION
There is no reason to run mesos-master service as root since
mesos-master process is only talking to other machines through http.

Change-Id: I7d6eaab1e097cf6adb274c9b040d50fdd3a4bfff