### PR TITLE
Configurable fd limits via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,7 @@ default['mesos']['package_options'] = case node['platform_family']
 default['mesos']['master']['bin']                   = '/usr/sbin/mesos-master'
 
 default['mesos']['master']['user']                  = 'mesosmaster'
+default['mesos']['master']['limit_nofile'] = 16384
 
 # Environmental variables set before calling the mesos master process.
 default['mesos']['master']['env'] = {}
@@ -43,7 +44,9 @@ default['mesos']['master']['flags']['work_dir']      = '/tmp/mesos'
 #
 
 # Mesos slave binary location.
-default['mesos']['slave']['bin']                    = '/usr/sbin/mesos-slave'
+default['mesos']['slave']['bin'] = '/usr/sbin/mesos-slave'
+
+default['mesos']['slave']['limit_nofile'] = 65536
 
 # Environmental variables set before calling the mesos-slave process.
 default['mesos']['slave']['env']                    = {}

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -88,7 +88,7 @@ systemd_service 'mesos-master' do
     exec_start '/etc/mesos-chef/mesos-master'
     restart 'on-failure'
     restart_sec 20
-    limit_nofile 16384
+    limit_nofile node['mesos']['master']['limit_nofile']
     user node['mesos']['master']['user']
   end
 

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -80,7 +80,7 @@ systemd_service 'mesos-slave' do
     exec_start '/etc/mesos-chef/mesos-slave'
     restart 'on-failure'
     restart_sec 20
-    limit_nofile 65536
+    limit_nofile node['mesos']['slave']['limit_nofile']
     delegate true
   end
 


### PR DESCRIPTION
  
    The goal is to be able to configure the number of file descriptors for
    both masters and agents.
