### PR TITLE
Don't start mesos-* services during chef-run

### DIFF
--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -96,5 +96,5 @@ end
 # Mesos master service definition
 service 'mesos-master' do
   supports status: true, restart: true
-  action %i[enable start]
+  action %i[enable]
 end

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -93,5 +93,5 @@ end
 
 service 'mesos-slave' do
   supports status: true, restart: true
-  action %i[enable start]
+  action %i[enable]
 end


### PR DESCRIPTION
Upon first run: many resource will trigger a restart anyway
After first run: it is not up to chef to start process if it crashed

Change-Id: I19b7622aed6e95356e281bf8e37d147c8441f085