### PR TITLE
Relax constraint on systemd cookbook

### DIFF
--- a/.kitchen.ec2.yml
+++ b/.kitchen.ec2.yml
@@ -26,7 +26,7 @@ busser:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.5.1
+  require_chef_omnibus: 14.7.17
 
 platforms:
   - name: centos-7

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,7 +6,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.14.60
+  require_chef_omnibus: 14.7.17
 
 platforms:
   - name: centos-7.2

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,5 +16,5 @@ supports 'centos'
   depends cookbook
 end
 
-depends 'systemd', '<= 3.2.2'
-chef_version '>= 11' if respond_to?(:chef_version)
+depends 'systemd'
+chef_version '>= 14' if respond_to?(:chef_version)


### PR DESCRIPTION
This forces us to require recent chef version

Change-Id: Ida967a5eb33097d8d84c3626c9d194856fba3b9e