### PR TITLE
Allow to configure mesos-slave service exec_start

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,6 +45,7 @@ default['mesos']['master']['flags']['work_dir']      = '/tmp/mesos'
 
 # Mesos slave binary location.
 default['mesos']['slave']['bin'] = '/usr/sbin/mesos-slave'
+default['mesos']['slave']['systemd_exec_start'] = '/etc/mesos-chef/mesos-slave'
 
 default['mesos']['slave']['limit_nofile'] = 65536
 

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -77,7 +77,7 @@ systemd_service 'mesos-slave' do
 
   service do
     environment_file '/etc/mesos-chef/mesos-slave-environment'
-    exec_start '/etc/mesos-chef/mesos-slave'
+    exec_start node['mesos']['slave']['systemd_exec_start']
     restart 'on-failure'
     restart_sec 20
     limit_nofile node['mesos']['slave']['limit_nofile']


### PR DESCRIPTION
Goal of this is to allow a wrapper cookbook to change easily what
systemd launches.
At criteo, we'll use this to make pre-decommission step by configuring
/bin/true as the binary launched by systemd

Change-Id: I61f2e73366beb0ceaa3ee1c3f48de4db0fbc34d8
JIRA: MESOS-4807