### PR TITLE
Use package resource instead of yum_package

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -26,12 +26,12 @@ include_recipe 'mesos::repo' if node['mesos']['repo']
 case node['platform_family']
 when 'rhel'
   %w[unzip libcurl subversion].each do |pkg|
-    yum_package pkg do
+    package pkg do
       action :install
     end
   end
 
-  yum_package 'mesos' do
+  package 'mesos' do
     if node['mesos']['version']
       version node['mesos']['version']
     else


### PR DESCRIPTION
On Centos8, yum has been removed in favor of dnf. Using package resource
will let chef chose the right backend directly.

JIRA: MESOS-4966