### PR TITLE
Bump java cookbook for Chef 18 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'foodcritic'
 gem 'rubocop', '= 0.60.0'
 gem 'serverspec'
 
-gem 'chef', '= 12.14.60'
+gem 'chef', '= 15.5.15'
 
 group :integration do
   gem 'kitchen-ec2'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,9 +12,7 @@ issues_url       'https://github.com/criteo-forks/mesos_cookbook/issues'
 
 supports 'centos'
 
-%w[java yum].each do |cookbook|
-  depends cookbook
-end
-
+depends 'java', '>= 8.1.0'
+depends 'yum'
 depends 'systemd'
-chef_version '>= 14' if respond_to?(:chef_version)
+chef_version '>= 15' if respond_to?(:chef_version)

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-include_recipe 'java'
+openjdk_pkg_install node['java']['jdk_version']
 
 include_recipe 'mesos::repo' if node['mesos']['repo']
 


### PR DESCRIPTION
The old version of java cookbook (< 8.0.0) has a dependency on homebrew cookbook which is not compatible with Chef 18. Newer versions remove the default recipe and instead uses resources to provide java installation. This commit refactors the code to use the provided resource instead and removes the constraint on java cookbook. At the same time, let's bump minimum chef version to the oldest supported by java 8.1.0 cookbook.